### PR TITLE
feature: enhance post-release action to support labels for easier release drafter exclusion

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -128,6 +128,7 @@ categories:
     labels:
       - 'revert'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+filter-by-commitish: true
 version-resolver:
   major:
     labels:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,12 +20,10 @@ on:
   push:
   pull_request:
     types: [ opened, reopened, synchronize ]
-  pull_request_target:
-    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 # queue jobs and only allow 1 run per branch due to the likelihood of hitting GitHub resource limits
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-pipeline-${{ github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: false
 jobs:
   update_release_draft:
@@ -36,7 +34,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: "🔢 Derive semver range from branch"
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          if [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "range=~${BRANCH%.x}.0" >> "$GITHUB_OUTPUT"
+          fi
       - name: "📝 Update Release Draft"
-        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
+        uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          commitish: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          filter-by-range: ${{ steps.version.outputs.range }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ env:
   REPO_SLUG: ${{ github.repository }}
   SVN_FOLDER: actions
   TAG: ${{ github.event.release.tag_name }}
+  TARGET_BRANCH: ${{ github.event.release.target_commitish }}
   VERSION: will be computed in each job
+concurrency:
+  group: release-pipeline-${{ github.event.release.target_commitish }}
+  cancel-in-progress: false
 jobs:
   test:
     name: 'Tests'

--- a/post-release/README.md
+++ b/post-release/README.md
@@ -40,6 +40,7 @@ Please note that the next version is derived from the provided `RELEASE_VERSION`
 * (optional) `RELEASE_VERSION` - The version of the release being closed. If not set, it will be derived from the `GITHUB_REF`, which as part of a release will be the tag name.
 * (optional) `RELEASE_TAG_PREFIX` - The prefix of the release tag. If not set, it will default to `v` (e.g., `v1.0.0`).
 * (optional) `PROPERTY_FILE_NAME` - defaults to `gradle.properties`, the property file containing the version property to update
+* (optional) `PR_LABELS` - comma-separated labels to apply to the merge-back pull request after it is created or reused
 * (optional) `RELEASE_SCRIPT_PATH` - An optional path to a custom shell script that will be executed after the version replacement in property file defined by `PROPERTY_FILE_NAME`, but prior to commiting the project changes.
 * (optional) `RELEASE_LATEST` - An optional boolean flag to update the GitHub release to be or not to be the latest. If not defined, no update will be performed.
 * (optional) `RELEASE_PRE_RELEASE` - An optional boolean flag to update the GitHub release to be or not to be a pre-release. If not defined, no update will be performed.
@@ -58,4 +59,12 @@ Running a custom script `myScript.sh` that's checked in under `.github/scripts`:
         uses: apache/grails-github-actions/post-release@asf
         env:
           RELEASE_SCRIPT_PATH: '.github/scripts/myScript.sh'
+```
+
+Adding labels to the merge-back pull request:
+```yaml
+      - name: "⚙️ Run post-release"
+        uses: apache/grails-github-actions/post-release@asf
+        with:
+          pr-labels: skip-changelog,internal-release
 ```

--- a/post-release/action.yml
+++ b/post-release/action.yml
@@ -20,9 +20,14 @@ inputs:
     description: 'GitHub token to authenticate the requests'  
     required: true
     default: ${{ github.token }}
+  pr-labels:
+    description: 'Optional comma-separated list of labels to add to the merge-back pull request'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
     GITHUB_API_URL: 'https://api.github.com'
     GITHUB_TOKEN: ${{ inputs.token }}
+    PR_LABELS: ${{ inputs.pr-labels }}

--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -78,6 +78,9 @@ set_value_or_error "${RELEASE_VERSION}" "${GITHUB_REF#refs/*/}" "RELEASE_VERSION
 set_value_or_error "${RELEASE_TAG_PREFIX}" "v" "RELEASE_TAG_PREFIX"
 set_value_or_error "${PROPERTY_FILE_NAME}" "gradle.properties" "PROPERTY_FILE_NAME"
 
+label_failure_message=""
+pr_failure_message=""
+
 echo "::group::Determine release version"
 if [[ ! "${RELEASE_VERSION}" =~ ^(${RELEASE_TAG_PREFIX})?[^.]+\.[^.]+\.[^.]+$ ]]; then
   echo "ERROR: RELEASE_VERSION must be in the format 'X.X.X' or '${RELEASE_TAG_PREFIX}X.X.X'. Got: '${RELEASE_VERSION}'"
@@ -164,17 +167,45 @@ echo "::endgroup::"
 echo "::group::Open/Reuse pull request"
 PR_TITLE="chore: merge ${RELEASE_VERSION}->${TARGET_BRANCH}; bump to ${NEXT_VERSION}-SNAPSHOT"
 PR_BODY="Automated snapshot bump after completing release ${RELEASE_VERSION}"
+PR_REFERENCE="${MERGE_BRANCH_NAME}"
 if ! gh pr create \
         --title "${PR_TITLE}" \
         --body  "${PR_BODY}" \
         --base  "${TARGET_BRANCH}" \
         --head  "${MERGE_BRANCH_NAME}" \
         --fill  >/tmp/pr-url 2>/tmp/pr-err; then
-    echo "PR likely exists – existing PR:" >&2
+    echo "PR creation failed. Checking for an existing PR:" >&2
     cat /tmp/pr-err
-    gh pr view "${MERGE_BRANCH_NAME}" --web || true
+    if PR_REFERENCE="$(gh pr view "${MERGE_BRANCH_NAME}" --web 2>/tmp/pr-view-err)"; then
+        echo "${PR_REFERENCE}"
+    else
+        cat /tmp/pr-view-err >&2
+        pr_failure_message="ERROR: Merge-back branch ${MERGE_BRANCH_NAME} was pushed, but pull request creation failed and no existing PR could be found. Create the PR manually."
+        echo "${pr_failure_message}" >&2
+        PR_REFERENCE=""
+    fi
 else
-    cat /tmp/pr-url
+    PR_REFERENCE="$(cat /tmp/pr-url)"
+    echo "${PR_REFERENCE}"
+fi
+
+if [[ -n "${PR_REFERENCE}" && -n "${PR_LABELS}" ]]; then
+    IFS=',' read -r -a pr_labels <<< "${PR_LABELS}"
+    label_args=()
+    for pr_label in "${pr_labels[@]}"; do
+        trimmed_label="$(printf '%s' "${pr_label}" | xargs)"
+        if [[ -n "${trimmed_label}" ]]; then
+            label_args+=(--add-label "${trimmed_label}")
+        fi
+    done
+
+    if [[ ${#label_args[@]} -gt 0 ]]; then
+        echo "Applying pull request labels: ${PR_LABELS}"
+        if ! gh pr edit "${PR_REFERENCE}" "${label_args[@]}"; then
+            label_failure_message="WARNING: Pull request ${PR_REFERENCE} was created or reused, but one or more labels could not be applied. Verify that all requested labels exist: ${PR_LABELS}"
+            echo "${label_failure_message}" >&2
+        fi
+    fi
 fi
 echo "::endgroup::"
 
@@ -210,3 +241,13 @@ else
     --data "${json_payload}"
 fi
 echo "::endgroup::"
+
+if [[ -n "${pr_failure_message}" ]]; then
+  echo "${pr_failure_message}" >&2
+  exit 1
+fi
+
+if [[ -n "${label_failure_message}" ]]; then
+  echo "${label_failure_message}" >&2
+  exit 1
+fi

--- a/tests/src/test/groovy/org/apache/grails/github/DeployGithubPagesSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/DeployGithubPagesSpec.groovy
@@ -96,6 +96,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "ghpages_html is set as root index_html"() {
@@ -155,6 +156,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "snapshot - snapshot publishing disabled"() {
@@ -203,6 +205,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "snapshot - published with subfolder"() {
@@ -257,6 +260,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "snapshot - published without subfolder"() {
@@ -310,6 +314,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "snapshot - published to different base path without subfolder"() {
@@ -366,6 +371,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "snapshot - version is ignored on snapshot"() {
@@ -419,6 +425,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "release - published without subfolder"() {
@@ -481,6 +488,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "release - published to different base path without subfolder"() {
@@ -547,6 +555,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "release - published with subfolder"() {
@@ -610,6 +619,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "release - skip publishing to latest"() {
@@ -672,6 +682,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "push retry - logs show successful deployment on first attempt"() {
@@ -716,6 +727,7 @@ class DeployGithubPagesSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "push retry - succeeds after initial push rejection"() {
@@ -784,6 +796,7 @@ exec "$REAL_GIT" "$@"
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "push retry - fails after maximum push attempts"() {
@@ -853,5 +866,6 @@ exec "$REAL_GIT" "$@"
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/DeployGithubPagesSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/DeployGithubPagesSpec.groovy
@@ -23,9 +23,21 @@ import org.apache.grails.github.mocks.GitHubVersion
 import org.apache.grails.github.mocks.GitHubRepoMock
 import org.apache.grails.github.mocks.cli.GitHubCliMock
 import org.testcontainers.containers.Network
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 class DeployGithubPagesSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    Network net = Network.newNetwork()
+
+    @AutoCleanup
+    GitHubDockerAction action
+
+    @AutoCleanup
+    GitHubRepoMock gitRepo
 
     private Map<String, String> getProjectFiles() {
         [
@@ -48,13 +60,10 @@ class DeployGithubPagesSpec extends Specification {
 
     def "gh-pages branch is created if does not exist"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -94,20 +103,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "ghpages_html is set as root index_html"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.createDivergedBranch([
@@ -154,20 +157,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "snapshot - snapshot publishing disabled"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -203,20 +200,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "snapshot - published with subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -258,20 +249,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "snapshot - published without subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -312,20 +297,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "snapshot - published to different base path without subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -369,20 +348,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "snapshot - version is ignored on snapshot"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -423,20 +396,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "release - published without subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -486,20 +453,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "release - published to different base path without subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -553,20 +514,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "release - published with subfolder"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -617,20 +572,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "release - skip publishing to latest"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -680,20 +629,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "push retry - logs show successful deployment on first attempt"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.stageRepositoryForAction('main', false)
@@ -725,20 +668,14 @@ class DeployGithubPagesSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "push retry - succeeds after initial push rejection"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.createDivergedBranch([
@@ -794,20 +731,14 @@ exec "$REAL_GIT" "$@"
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "push retry - fails after maximum push attempts"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
+        action = new GitHubDockerAction('deploy-github-pages', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], getProjectFiles())
         gitRepo.createDivergedBranch([
@@ -864,8 +795,5 @@ exec "$REAL_GIT" "$@"
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/ExportGradlePropertiesSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/ExportGradlePropertiesSpec.groovy
@@ -77,6 +77,7 @@ other=another
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "export gradle properties with prefix"() {
@@ -127,6 +128,7 @@ other=another
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "export gradle properties with prefix ending in underscore"() {
@@ -175,6 +177,7 @@ foo=testing
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "export gradle properties with inline comments"() {
@@ -226,6 +229,7 @@ bar=value# no space before hash
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "export gradle properties with equals signs in values"() {
@@ -275,5 +279,6 @@ base64=dGVzdD0xMjM=
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/ExportGradlePropertiesSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/ExportGradlePropertiesSpec.groovy
@@ -23,19 +23,28 @@ import org.apache.grails.github.mocks.GitHubRepoMock
 import org.apache.grails.github.mocks.GitHubVersion
 import org.apache.grails.github.mocks.cli.GitHubCliMock
 import org.testcontainers.containers.Network
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 import java.nio.file.Files
 
 class ExportGradlePropertiesSpec extends Specification {
 
+    @Shared
+    @AutoCleanup
+    Network net = Network.newNetwork()
+
+    @AutoCleanup
+    GitHubDockerAction action
+
+    @AutoCleanup
+    GitHubRepoMock gitRepo
+
     def "export gradle properties"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
+        action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
 
         and:
         String gradleProperties = """
@@ -45,7 +54,7 @@ other=another
 """
 
         and:
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], ['gradle.properties': gradleProperties])
         gitRepo.stageRepositoryForAction('main', false)
@@ -75,18 +84,12 @@ other=another
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "export gradle properties with prefix"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
+        action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
 
         and:
         String gradleProperties = """
@@ -97,7 +100,7 @@ other=another
 """
 
         and:
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], ['gradle.properties': gradleProperties])
         gitRepo.stageRepositoryForAction('main', false)
@@ -126,18 +129,12 @@ other=another
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "export gradle properties with prefix ending in underscore"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
+        action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
 
         and:
         String gradleProperties = """
@@ -146,7 +143,7 @@ foo=testing
 """
 
         and:
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], ['gradle.properties': gradleProperties])
         gitRepo.stageRepositoryForAction('main', false)
@@ -175,18 +172,12 @@ foo=testing
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "export gradle properties with inline comments"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
+        action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
 
         and:
         String gradleProperties = """
@@ -198,7 +189,7 @@ bar=value# no space before hash
 """
 
         and:
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], ['gradle.properties': gradleProperties])
         gitRepo.stageRepositoryForAction('main', false)
@@ -227,18 +218,12 @@ bar=value# no space before hash
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "export gradle properties with equals signs in values"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
+        action = new GitHubDockerAction('export-gradle-properties', release, new GitHubCliMock())
 
         and:
         String gradleProperties = """
@@ -248,7 +233,7 @@ base64=dGVzdD0xMjM=
 """
 
         and:
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', null, [], ['gradle.properties': gradleProperties])
         gitRepo.stageRepositoryForAction('main', false)
@@ -277,8 +262,5 @@ base64=dGVzdD0xMjM=
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
@@ -23,19 +23,28 @@ import org.apache.grails.github.mocks.GitHubVersion
 import org.apache.grails.github.mocks.GitHubRepoMock
 import org.apache.grails.github.mocks.cli.GitHubCliMock
 import org.testcontainers.containers.Network
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 class PostReleaseSpec extends Specification {
 
+    @Shared
+    @AutoCleanup
+    Network net = Network.newNetwork()
+
+    @AutoCleanup
+    GitHubDockerAction action
+
+    @AutoCleanup
+    GitHubRepoMock gitRepo
+
     def 'success - merge pr created - custom tag prefix'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'rel-7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('rel-7.0.0-RC1', '7.0.0-RC1')
@@ -82,20 +91,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def "success - different property file name"() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'], [
                 'README.md'     : '# demo\n',
@@ -142,20 +145,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - merge pr created - tag v7.0.0-RC1 to 7.0.x branch'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -201,20 +198,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - labels applied to created merge pr'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -239,19 +230,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
     }
 
     def 'success - labels applied when merge pr already exists'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -275,19 +261,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
     }
 
     def 'failure - create pr fails and no existing pr is found'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -324,19 +305,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
     }
 
     def 'success - pre-release forced update'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -384,20 +360,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - latest forced update'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -445,20 +415,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - latest and prerelease forced update'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -507,20 +471,14 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - merge pr created - tag v7.0.0-RC1 to main branch'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: 'main', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+        action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', [])
         gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
@@ -566,8 +524,5 @@ class PostReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
@@ -203,6 +203,128 @@ class PostReleaseSpec extends Specification {
         action.close()
     }
 
+    def 'success - labels applied to created merge pr'() {
+        given:
+        Network net = Network.newNetwork()
+
+        and:
+        GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
+        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+
+        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo.init()
+        gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
+        gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
+        gitRepo.stageRepositoryForAction('v7.0.0-RC1', true)
+
+        and:
+        def env = action.getDefaultEnvironment()
+        env['GH_MOCK_PR_CREATE'] = 'create'
+        env['PR_LABELS'] = 'skip-changelog, internal-release'
+
+        and:
+        action.createContainer(env, net)
+
+        when:
+        action.runAction()
+
+        then:
+        action.actionExitCode == 0L
+        action.getActionGroupLogs('Open/Reuse pull request').contains('https://github.com/mock-org/mock-repo/pull/42')
+        action.getActionGroupLogs('Open/Reuse pull request').contains('Applying pull request labels: skip-changelog, internal-release')
+        action.getActionGroupLogs('Open/Reuse pull request').contains('ref=https://github.com/mock-org/mock-repo/pull/42 labels=skip-changelog,internal-release')
+
+        cleanup:
+        System.out.println("Container logs:\n${action.actionLogs}" as String)
+        gitRepo?.close()
+        action.close()
+    }
+
+    def 'success - labels applied when merge pr already exists'() {
+        given:
+        Network net = Network.newNetwork()
+
+        and:
+        GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
+        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+
+        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo.init()
+        gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
+        gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
+        gitRepo.stageRepositoryForAction('v7.0.0-RC1', true)
+
+        and:
+        def env = action.getDefaultEnvironment()
+        env['GH_MOCK_PR_CREATE'] = 'exists'
+        env['PR_LABELS'] = 'skip-changelog'
+
+        and:
+        action.createContainer(env, net)
+
+        when:
+        action.runAction()
+
+        then:
+        action.actionExitCode == 0L
+        action.getActionGroupLogs('Open/Reuse pull request').contains('Applying pull request labels: skip-changelog')
+        action.getActionGroupLogs('Open/Reuse pull request').contains('ref=https://github.com/mock-org/mock-repo/pull/42 labels=skip-changelog')
+
+        cleanup:
+        System.out.println("Container logs:\n${action.actionLogs}" as String)
+        gitRepo?.close()
+        action.close()
+    }
+
+    def 'failure - create pr fails and no existing pr is found'() {
+        given:
+        Network net = Network.newNetwork()
+
+        and:
+        GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: '7.0.x', targetVersion: '7.0.0-SNAPSHOT')
+        GitHubDockerAction action = new GitHubDockerAction('post-release', release, new GitHubCliMock())
+
+        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo.init()
+        gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', ['7.0.x'])
+        gitRepo.setProjectVersion('v7.0.0-RC1', '7.0.0-RC1')
+        gitRepo.stageRepositoryForAction('v7.0.0-RC1', true)
+
+        and:
+        def env = action.getDefaultEnvironment()
+        env['GH_MOCK_PR_CREATE'] = 'fail'
+        env['GH_MOCK_PR_VIEW'] = 'fail'
+        env['RELEASE_LATEST'] = 'true'
+
+        and:
+        action.createContainer(env, net)
+
+        when:
+        action.runAction()
+
+        then:
+        def e = thrown(org.testcontainers.containers.ContainerLaunchException)
+        e.message.contains('Container startup failed')
+
+        and: 'logs capture the real failure mode'
+        action.actionLogs.contains('PR creation failed. Checking for an existing PR:')
+        action.actionLogs.contains('gh-mock: simulated failure creating PR')
+        action.actionLogs.contains('gh-mock: simulated failure viewing PR')
+        action.actionLogs.contains('ERROR: Merge-back branch merge-back-7.0.0-RC1 was pushed, but pull request creation failed and no existing PR could be found. Create the PR manually.')
+
+        and: 'merge branch and version bump were still produced before failing'
+        gitRepo.branchExists('merge-back-7.0.0-RC1')
+        gitRepo.getRefProjectVersion('merge-back-7.0.0-RC1') == '7.0.0-SNAPSHOT'
+
+        and: 'later workflow steps still executed before the final failure'
+        action.getActionGroupLogs('Update Release Status').contains('PATCH payload: {"make_latest": "true"}')
+
+        cleanup:
+        System.out.println("Container logs:\n${action.actionLogs}" as String)
+        gitRepo?.close()
+        action.close()
+    }
+
     def 'success - pre-release forced update'() {
         given:
         Network net = Network.newNetwork()

--- a/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/PostReleaseSpec.groovy
@@ -84,6 +84,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def "success - different property file name"() {
@@ -143,6 +144,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - merge pr created - tag v7.0.0-RC1 to 7.0.x branch'() {
@@ -201,6 +203,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - labels applied to created merge pr'() {
@@ -383,6 +386,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - latest forced update'() {
@@ -443,6 +447,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - latest and prerelease forced update'() {
@@ -504,6 +509,7 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - merge pr created - tag v7.0.0-RC1 to main branch'() {
@@ -562,5 +568,6 @@ class PostReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/PreReleaseSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/PreReleaseSpec.groovy
@@ -22,19 +22,28 @@ import org.apache.grails.github.mocks.GitHubDockerAction
 import org.apache.grails.github.mocks.GitHubVersion
 import org.apache.grails.github.mocks.GitHubRepoMock
 import org.testcontainers.containers.Network
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 class PreReleaseSpec extends Specification {
 
+    @Shared
+    @AutoCleanup
+    Network net = Network.newNetwork()
+
+    @AutoCleanup
+    GitHubDockerAction action
+
+    @AutoCleanup
+    GitHubRepoMock gitRepo
+
     def 'success - tag v7.0.0-RC1 updated with version'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: 'main', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('pre-release', release)
+        action = new GitHubDockerAction('pre-release', release)
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', [])
         gitRepo.stageRepositoryForAction('v7.0.0-RC1', true)
@@ -70,20 +79,14 @@ class PreReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - different property file name'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'v7.0.0-RC1', targetBranch: 'main', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('pre-release', release)
+        action = new GitHubDockerAction('pre-release', release)
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'v7.0.0-RC1', [], [
                 'README.md'     : '# demo\n',
@@ -123,20 +126,14 @@ class PreReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 
     def 'success - tag with custom prefix updated with version'() {
         given:
-        Network net = Network.newNetwork()
-
-        and:
         GitHubVersion release = new GitHubVersion(version: '7.0.0-RC1', tagName: 'rel-7.0.0-RC1', targetBranch: 'main', targetVersion: '7.0.0-SNAPSHOT')
-        GitHubDockerAction action = new GitHubDockerAction('pre-release', release)
+        action = new GitHubDockerAction('pre-release', release)
 
-        GitHubRepoMock gitRepo = new GitHubRepoMock(action.workspacePath, net)
+        gitRepo = new GitHubRepoMock(action.workspacePath, net)
         gitRepo.init()
         gitRepo.populateRepository('7.0.0-SNAPSHOT', 'rel-7.0.0-RC1', [])
         gitRepo.stageRepositoryForAction('rel-7.0.0-RC1', true)
@@ -173,8 +170,5 @@ class PreReleaseSpec extends Specification {
 
         cleanup:
         System.out.println("Container logs:\n${action.actionLogs}" as String)
-        gitRepo?.close()
-        action.close()
-        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/PreReleaseSpec.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/PreReleaseSpec.groovy
@@ -72,6 +72,7 @@ class PreReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - different property file name'() {
@@ -124,6 +125,7 @@ class PreReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 
     def 'success - tag with custom prefix updated with version'() {
@@ -173,5 +175,6 @@ class PreReleaseSpec extends Specification {
         System.out.println("Container logs:\n${action.actionLogs}" as String)
         gitRepo?.close()
         action.close()
+        net?.close()
     }
 }

--- a/tests/src/test/groovy/org/apache/grails/github/mocks/cli/GitHubCliMock.groovy
+++ b/tests/src/test/groovy/org/apache/grails/github/mocks/cli/GitHubCliMock.groovy
@@ -56,7 +56,7 @@ case "\$cmd" in
 
         case "\$mode" in
           create)
-            printf "%s\n"
+            printf "%s\n" "https://github.com/mock-org/mock-repo/pull/42"
             exit 0
             ;;
           exists)
@@ -75,7 +75,37 @@ case "\$cmd" in
         ;;
       view)
         # Accept: gh pr view <branch> --web
-        # Simulate success
+        mode="\${GH_MOCK_PR_VIEW:-success}"
+        if [ "\$mode" = "fail" ]; then
+          echo "gh-mock: simulated failure viewing PR" >&2
+          exit 1
+        fi
+        printf "%s\n" "https://github.com/mock-org/mock-repo/pull/42"
+        exit 0
+        ;;
+      edit)
+        ref="\${1:-}"; shift || true
+        labels=""
+        while [ "\$#" -gt 0 ]; do
+          case "\$1" in
+            --add-label)
+              if [ -n "\$labels" ]; then
+                labels="\$labels,\$2"
+              else
+                labels="\$2"
+              fi
+              shift 2
+              ;;
+            *)
+              shift
+              ;;
+          esac
+        done
+        if [ "\${GH_MOCK_PR_EDIT:-success}" = "invalid-label" ]; then
+          echo "could not add label: label not found" >&2
+          exit 1
+        fi
+        printf 'ref=%s labels=%s\n' "\$ref" "\$labels"
         exit 0
         ;;
       *)


### PR DESCRIPTION
While preparing the grails-core 7.1.0 release I noticed several issues: 
1. the drafter wasn't pinned to a specific sha
2. better error handling was needed around PR creation (if permission aren't setup correctly, etc)
3. there wasn't a way to add a PR label as part of the merge action
4. we could use drafter to auto-exclude the merge commits to reduce noise on the drafter notes