### PR TITLE
Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@
 name: "CI"
 on:
   push:
+    branches:
+      - asf
+      - main
   pull_request:
   workflow_dispatch:
 # queue jobs and only allow 1 run per branch due to the likelihood of hitting GitHub resource limits

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -16,6 +16,9 @@
 name: "Licensing - RAT Report"
 on:
   push:
+    branches:
+      - asf
+      - main
   pull_request:
   workflow_dispatch:
 # queue jobs and only allow 1 run per branch due to the likelihood of hitting GitHub resource limits


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches